### PR TITLE
Pass ctx down to http calls

### DIFF
--- a/libsql/internal/http/driver.go
+++ b/libsql/internal/http/driver.go
@@ -89,7 +89,7 @@ func convertArgs(args []driver.NamedValue) params {
 }
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	_, err := callSqld(c.url, query, convertArgs(args))
+	_, err := callSqld(ctx, c.url, query, convertArgs(args))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 }
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	rs, err := callSqld(c.url, query, convertArgs(args))
+	rs, err := callSqld(ctx, c.url, query, convertArgs(args))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Though the `ExecContext` and `QueryContext` take ctx parameter, they were not using them. This PR, makes these methods to pass them to `callSqld` method, which can be used in http calls.

E.g. if a user wants to cancel the operation if it isn't completed in under 1 second, the code would be:

```go
ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
defer cancel()
res, err := db.QueryContext(ctx, stmt, args...)
```