### PR TITLE
Pass ctx down to websocket calls

### DIFF
--- a/libsql/internal/http/http.go
+++ b/libsql/internal/http/http.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/xwb1989/sqlparser"
 )
+
+var httpClient = &http.Client{Timeout: 120 * time.Second}
 
 type params struct {
 	Names  []string
@@ -68,7 +71,7 @@ func callSqld(ctx context.Context, url string, sql string, sqlParams params) (*r
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/libsql/internal/ws/driver.go
+++ b/libsql/internal/ws/driver.go
@@ -86,11 +86,15 @@ func convertToNamed(args []driver.Value) []driver.NamedValue {
 }
 
 func (s stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return s.c.ExecContext(context.TODO(), s.query, convertToNamed(args))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultWSTimeout)
+	defer cancel()
+	return s.c.ExecContext(ctx, s.query, convertToNamed(args))
 }
 
 func (s stmt) Query(args []driver.Value) (driver.Rows, error) {
-	return s.c.QueryContext(context.TODO(), s.query, convertToNamed(args))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultWSTimeout)
+	defer cancel()
+	return s.c.QueryContext(ctx, s.query, convertToNamed(args))
 }
 
 func (c *conn) Prepare(query string) (driver.Stmt, error) {

--- a/libsql/internal/ws/driver.go
+++ b/libsql/internal/ws/driver.go
@@ -154,7 +154,7 @@ func convertArgs(args []driver.NamedValue) params {
 }
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	res, err := c.ws.exec(query, convertArgs(args), false)
+	res, err := c.ws.exec(ctx, query, convertArgs(args), false)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 }
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	res, err := c.ws.exec(query, convertArgs(args), true)
+	res, err := c.ws.exec(ctx, query, convertArgs(args), true)
 	if err != nil {
 		return nil, err
 	}

--- a/libsql/internal/ws/websockets.go
+++ b/libsql/internal/ws/websockets.go
@@ -12,7 +12,9 @@ import (
 	"vitess.io/vitess/go/pools"
 )
 
-var defaultConnTimeout = 120 * time.Second
+// defaultWSTimeout specifies the timeout used for initial http connection and
+// the subsequent websocket read/write operations
+var defaultWSTimeout = 120 * time.Second
 
 func errorMsg(errorResp interface{}) string {
 	return errorResp.(map[string]interface{})["error"].(map[string]interface{})["message"].(string)
@@ -178,7 +180,7 @@ func (ws *websocketConn) Close() error {
 }
 
 func connect(url string, jwt string) (*websocketConn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultConnTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultWSTimeout)
 	defer cancel()
 	c, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{
 		Subprotocols: []string{"hrana1"},


### PR DESCRIPTION
This PR, makes the internal methods to pass ctx to websocket library. 

- Updated `ExecContext` and `QueryContext`, they will pass the ctx down
- In the connect call, a new ctx with timeout is created and is passed to `wsjson`
- I have done same in `Exec` and `Query` methods too.

Also, taking from the discussion https://github.com/libsql/libsql-client-go/issues/9#issuecomment-1511408276 I have added timeout of 120 seconds to both websocket and http calls. 