### PR TITLE
fix: http return int64 for int column

### DIFF
--- a/libsql/internal/http/driver.go
+++ b/libsql/internal/http/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 )
 
@@ -40,7 +41,20 @@ func (r *rows) Next(dest []driver.Value) error {
 	}
 	count := len(r.result.Rows[r.currentRowIdx])
 	for idx := 0; idx < count; idx++ {
-		dest[idx] = r.result.Rows[r.currentRowIdx][idx]
+		value := r.result.Rows[r.currentRowIdx][idx]
+		dest[idx] = value
+		switch v := value.(type) {
+		case int64:
+			dest[idx] = int64(v)
+		case float64:
+			if math.Mod(v, 1) >= 0 {
+				dest[idx] = int64(v)
+			} else {
+				dest[idx] = v
+			}
+		default:
+			dest[idx] = value
+		}
 	}
 	r.currentRowIdx++
 	return nil


### PR DESCRIPTION
fixes: #28 

Have added a check for the type of value in the `Next` method, it will only cast true integers to `int64` which have been set as `float64` as a bug.

Will it be sufficient to handle all the cases? I am new to the repository, so I have tested with a local connection to the libsql database and it does convert the value to int.

Let me know for any other improvements that can be added, or is this a valid fix?
Thank you