### PR TITLE
fix file url with double slash error message

### DIFF
--- a/libsql/sql.go
+++ b/libsql/sql.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/libsql/libsql-client-go/libsql/internal/http"
 	"github.com/libsql/libsql-client-go/libsql/internal/ws"
-	"net/url"
 )
 
 func contains(s []string, item string) bool {
@@ -77,6 +79,9 @@ func (d *LibsqlDriver) Open(dbUrl string) (driver.Conn, error) {
 		return nil, err
 	}
 	if u.Scheme == "file" {
+		if strings.HasPrefix(dbUrl, "file://") && !strings.HasPrefix(dbUrl, "file:///") {
+			return nil, fmt.Errorf("invalid database URL: %s. File URLs should not have double leading slashes. ", dbUrl)
+		}
 		expectedDrivers := []string{"sqlite", "sqlite3"}
 		presentDrivers := sql.Drivers()
 		for _, expectedDriver := range expectedDrivers {


### PR DESCRIPTION
Addressing #37 

- Added check if the file schema URL has double leading slash
- Added an appropriate error message on such file URLs

Please let me know if it is a valid fix, or if I need to make changes further.
Thank you.