### PR TITLE
implement websocket auto reconnect

### DIFF
--- a/libsql/internal/ws/websockets.go
+++ b/libsql/internal/ws/websockets.go
@@ -117,6 +117,11 @@ func (r *execResponse) value(rowIdx int, colIdx int) (any, error) {
 }
 
 func (ws *websocketConn) exec(ctx context.Context, sql string, sqlParams params, wantRows bool) (*execResponse, error) {
+	deadline, _ := ctx.Deadline()
+	timeout := time.Until(deadline)
+	halfTimeout := timeout / 2
+	ctx, cancel := context.WithTimeout(context.Background(), halfTimeout)
+	defer cancel()
 	requestId := ws.idPool.Get()
 	defer ws.idPool.Put(requestId)
 	stmt := map[string]interface{}{


### PR DESCRIPTION
Currently there is no support for reconnecting websocket after it's dropped by the server. This commit adds `timeOpen` property to track when the client is connected to the server, and will reconnect the connection if request's age is more than 60 seconds.