### PR TITLE
Ensure multi-line statements work

### DIFF
--- a/libsql/internal/hrana/stream_request.go
+++ b/libsql/internal/hrana/stream_request.go
@@ -41,8 +41,9 @@ func ExecuteStoredStream(sqlId int32, params shared.Params, wantRows bool) (*Str
 func BatchStream(sqls []string, params []shared.Params, wantRows bool) (*StreamRequest, error) {
 	batch := &Batch{}
 	for idx, sql := range sqls {
+		s := sql
 		stmt := &Stmt{
-			Sql:      &sql,
+			Sql:      &s,
 			WantRows: wantRows,
 		}
 		if err := stmt.AddArgs(params[idx]); err != nil {


### PR DESCRIPTION
The following code does not work on the main branch: https://gist.github.com/rylev/b28e503d33b3dbf7f45843903cb3da3a.

This fixes the very subtle bug where by the last statement was being repeatedly referenced instead of each statement being referenced individually. 

I've added a test to prevent regressions.