### PR TITLE
bugfix: run tests according to protocol

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,4 +47,5 @@ jobs:
       - name: Test
         run: go test -v ./...
         env:
-          LIBSQL_TEST_DB_URL: "http://127.0.0.1:8080"
+          LIBSQL_TEST_HTTP_DB_URL: "http://127.0.0.1:8080"
+          LIBSQL_TEST_WS_DB_URL: "ws://127.0.0.1:8080"

--- a/tests/http/driver_test.go
+++ b/tests/http/driver_test.go
@@ -40,7 +40,7 @@ type Database struct {
 }
 
 func getDb(t T) Database {
-	dbURL := os.Getenv("LIBSQL_TEST_DB_URL")
+	dbURL := os.Getenv("LIBSQL_TEST_HTTP_DB_URL")
 	db, err := sql.Open("libsql", dbURL)
 	t.FatalOnError(err)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/tests/ws/driver_test.go
+++ b/tests/ws/driver_test.go
@@ -13,7 +13,7 @@ import (
 
 // setupDB sets up a test database by connecting to libsql server and creates a `test` table
 func setupDB(ctx context.Context, t *testing.T) *sql.DB {
-	dbURL := os.Getenv("LIBSQL_TEST_DB_URL")
+	dbURL := os.Getenv("LIBSQL_TEST_WS_DB_URL")
 	db, err := sql.Open("libsql", dbURL)
 	if err != nil {
 		t.Fatal(err)
@@ -216,7 +216,7 @@ func TestPreparedStatementsWithTransactionsRollback(t *testing.T) {
 }
 
 func TestCancelContext(t *testing.T) {
-	dbURL := os.Getenv("LIBSQL_TEST_DB_URL")
+	dbURL := os.Getenv("LIBSQL_TEST_WS_DB_URL")
 	db, err := sql.Open("libsql", dbURL)
 	if err != nil {
 		t.Fatal(err)
@@ -264,7 +264,7 @@ func TestCancelTransactionWithContext(t *testing.T) {
 }
 
 func TestDataTypes(t *testing.T) {
-	dbURL := os.Getenv("LIBSQL_TEST_DB_URL")
+	dbURL := os.Getenv("LIBSQL_TEST_WS_DB_URL")
 	db, err := sql.Open("libsql", dbURL)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
we have protocol specific tests in `tests/`, however both `tests/http` and `tests/ws` were using same protocol `http` since we set a single environment variable and use the same at both places. I changed it to protocol specific ones to make it explicit and updated the correct URLs at both places