### PR TITLE
Fix server error handling

### DIFF
--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -157,6 +157,12 @@ func (h *hranaV2Conn) sendPipelineRequest(ctx context.Context, msg *hrana.Pipeli
 	if resp.StatusCode != http.StatusOK {
 		// We need to remember that the stream is closed so we don't try to send any more requests using this connection.
 		h.streamClosed = true
+		var serverError struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &serverError); err == nil {
+			return nil, fmt.Errorf("error code %d: %s", resp.StatusCode, serverError.Error)
+		}
 		var errResponse hrana.Error
 		if err := json.Unmarshal(body, &errResponse); err == nil {
 			if errResponse.Code != nil {


### PR DESCRIPTION
If the server returns 401, for example, it is *not* in the same format as Hrana errors. Therefore, first attempt to parse a server error and only then parse Hrana errors.

For example, the following error:

Error: failed to connect to database. err: failed to execute SQL: SELECT 1;

now becomes:

Error: failed to connect to database. err: failed to execute SQL: SELECT 1;
error code 401: Unauthorized: `The `Authorization` HTTP header is required but was not specified`