### PR TITLE
Fix boolean scan and detect TIMESTAMP type

### DIFF
--- a/libsql/internal/hrana/value.go
+++ b/libsql/internal/hrana/value.go
@@ -45,6 +45,7 @@ func (v Value) ToValue(columnType *string) any {
 			}
 		}
 	}
+
 	return v.Value
 }
 


### PR DESCRIPTION
This PR fixes scanning for a Boolean type and also detecting a `TIMESTAMP` as it comes in from a column of a query.