### PR TITLE
Improve ResetSession by not sending requests

### DIFF
--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -397,9 +397,12 @@ func (h *hranaV2Conn) closeStream(ctx context.Context) error {
 
 func (h *hranaV2Conn) ResetSession(ctx context.Context) error {
 	if h.baton != "" {
-		err := h.closeStream(ctx)
+		go func(baton, url, jwt, host string) {
+			msg := hrana.PipelineRequest{Baton: baton}
+			msg.Add(hrana.CloseStream())
+			_, _, _ = sendPipelineRequest(context.Background(), &msg, url, jwt, host)
+		}(h.baton, h.url, h.jwt, h.host)
 		h.baton = ""
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Instead mark connection as `closeStreamOnNextRequest` and prepend `StreamClose` request to the pipeline before the next request.

Fixes #84 