### PR TITLE
fix: always check against lowercase

### DIFF
--- a/libsql/internal/hrana/value.go
+++ b/libsql/internal/hrana/value.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -27,7 +28,7 @@ func (v Value) ToValue(columnType *string) any {
 		}
 		return integer
 	} else if columnType != nil {
-		if (*columnType == "TIMESTAMP" || *columnType == "DATETIME") && v.Type == "text" {
+		if (strings.ToLower(*columnType) == "timestamp" || strings.ToLower(*columnType) == "datetime") && v.Type == "text" {
 			for _, format := range []string{
 				"2006-01-02 15:04:05.999999999-07:00",
 				"2006-01-02T15:04:05.999999999-07:00",


### PR DESCRIPTION
For me these values are lowercase. I'm unsure when they are upper case, but this fixes it so the comparison is always lowercase, without this I was hitting unsupported scan errors. Also everything else happens to be lowercase as well, so I'm unsure if the `strings.ToLower` is required, but I put it there just in case the values can be all caps.
